### PR TITLE
Change symengine requirement to >= instead of ==

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(name='timesynth',
       license='MIT',
       include_package_data=True,
       packages=find_packages(),
-      install_requires=['numpy', 'scipy', 'sympy', 'symengine==0.4', 'jitcdde==1.4', 'jitcxde_common==1.4.1'],
+      install_requires=['numpy', 'scipy', 'sympy', 'symengine>=0.4', 'jitcdde==1.4', 'jitcxde_common==1.4.1'],
       tests_require=['pytest'],
       setup_requires=["pytest-runner"])


### PR DESCRIPTION
Before:
`symengine==0.4.0` meant it was not possible to use this library in Python 3.8

Now:
`symengine>=0.4.0` means symengine is not keeping this library out of Python 3.8

closes #19